### PR TITLE
Only parse json if content type justifies it

### DIFF
--- a/lib/nomis/api/auth_token.rb
+++ b/lib/nomis/api/auth_token.rb
@@ -74,15 +74,13 @@ module NOMIS
       end
 
       def default_client_key(params = {})
-        read_client_key_file(
-          params[:client_key_file] || ENV['NOMIS_API_CLIENT_KEY_FILE']
-        )
+        path = params[:client_key_file] || ENV['NOMIS_API_CLIENT_KEY_FILE']
+        path ? read_client_key_file(path) : nil
       end
       
       def default_client_token(params = {})
-        read_client_key_file(
-          params[:client_token_file] || ENV['NOMIS_API_CLIENT_TOKEN_FILE']
-        )
+        path = params[:client_token_file] || ENV['NOMIS_API_CLIENT_TOKEN_FILE']
+        path ? read_client_key_file(path) : nil
       end
 
       def default_iat_fudge_factor(params={})

--- a/lib/nomis/api/parsed_response.rb
+++ b/lib/nomis/api/parsed_response.rb
@@ -9,12 +9,18 @@ module NOMIS
 
       def initialize(raw_response)
         self.raw_response = raw_response
-        self.data = JSON.parse(raw_response.body)
+        self.data = parse(raw_response)
       end
 
       def body
         raw_response.body
       end
+
+      def parse(response)
+        response.content_type == 'application/json' ? \
+            JSON.parse(response.body) : response.body
+      end
+
       def status
         raw_response.code
       end

--- a/nomis_api_client_ruby.gemspec
+++ b/nomis_api_client_ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'nomis-api-client'
-  s.version     = '0.1.2'
+  s.version     = '0.1.3'
   s.date        = '2017-06-02'
   s.summary     = "Minimal Ruby client for the NOMIS API"
   s.description = "A minimal Ruby client for the [NOMIS API](http://ministryofjustice.github.io/nomis-api/)"

--- a/spec/lib/nomis/api/parsed_response_spec.rb
+++ b/spec/lib/nomis/api/parsed_response_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require 'nomis/api'
+
+describe NOMIS::API::ParsedResponse do
+  describe '#parse' do
+    subject{ described_class.new(response) }
+
+    context 'given a response' do
+      let(:response){ double(:response, content_type: content_type, body: body) }
+
+      context 'with content type of application/json' do
+        let(:content_type){ 'application/json' }
+        let(:body){ '{"a_key": "a value"}' }
+
+        it 'returns the body parsed as JSON' do
+          expect(subject.send(:parse, response)).to eq( {'a_key' => 'a value'} )
+        end
+      end
+
+      context 'with a non-JSON content type' do
+        let(:content_type){ 'text/html' }
+        let(:body){ 'DB is down' }
+
+        it 'returns the body as-is' do
+          expect(subject.send(:parse, response)).to eq(body)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new 'health' endpoint returns a plain text body with a content-type of text/html. This breaks the ParsedResponse class which was assuming all responses would be JSON.

This commit fixes #2 by only parsing the body as JSON if the response content-type is application/json, otherwise it returns the body as-is.